### PR TITLE
Rebundle with ruby-2.7.4 to match GitHub Actions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,12 +226,16 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
+    mini_portile2 (2.8.5)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.15.0)
     multipart-post (2.1.1)
+    nokogiri (1.13.6)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     nokogiri (1.13.6-x86_64-darwin)
       racc (~> 1.4)
     octokit (4.22.0)
@@ -273,6 +277,7 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
+  ruby
   x86_64-darwin-19
 
 DEPENDENCIES
@@ -282,4 +287,4 @@ DEPENDENCIES
   jekyll-github-metadata
 
 BUNDLED WITH
-   2.3.14
+   2.1.4


### PR DESCRIPTION
GitHub Actions logs had:

```
Warning: the running version of Bundler (2.1.4) is older than the version that created the lockfile (2.3.14). We suggest you to upgrade to the version that created the lockfile by running `gem install bundler:2.3.14`.

Warning:  github-pages can't satisfy your Gemfile's dependencies.
```